### PR TITLE
refactor: Simplificar verificação de versão existente no PyPI no work…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,10 +101,8 @@ jobs:
           fi
           # Check if the version exists on PyPI
           echo "Checking PyPI for version $VERSION"
-          if [ -z "$(curl -s https://pypi.org/pypi/timecraft-ai/$VERSION/json)" ]; then
-            echo "Version $VERSION does not exist on PyPI"
-          else
-            echo "Version $VERSION exists on PyPI"
+          if curl -s https://pypi.org/pypi/timecraft-ai/v1.1.1/json | grep -v 'Not Found' -q; then
+            echo "Version $VERSION already exists on PyPI"
             exit 1
           fi
         env:


### PR DESCRIPTION
This pull request updates the `publish.yml` workflow to improve the version existence check for PyPI. The change ensures that the script correctly identifies whether a specific version already exists on PyPI and exits with an error if it does.

Key change:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L104-R105): Replaced the logic for checking version existence on PyPI. The updated script uses a specific version (`v1.1.1`) in the URL and checks for the absence of "Not Found" in the response to determine if the version already exists. If it does, the script exits with an error.